### PR TITLE
[FEAT] 도서 좋아요 API 구현

### DIFF
--- a/src/main/java/com/pagely/bookservice/application/dto/command/CreateBookLikeCommand.java
+++ b/src/main/java/com/pagely/bookservice/application/dto/command/CreateBookLikeCommand.java
@@ -1,0 +1,23 @@
+package com.pagely.bookservice.application.dto.command;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateBookLikeCommand {
+    @NotBlank
+    @Size(max = 20)
+    private String bookId;
+
+    @NotNull
+    private UUID userId;
+}

--- a/src/main/java/com/pagely/bookservice/application/dto/command/DeleteBookLikeCommand.java
+++ b/src/main/java/com/pagely/bookservice/application/dto/command/DeleteBookLikeCommand.java
@@ -1,0 +1,23 @@
+package com.pagely.bookservice.application.dto.command;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteBookLikeCommand {
+    @NotBlank
+    @Size(max = 20)
+    private String bookId;
+
+    @NotNull
+    private UUID userId;
+}

--- a/src/main/java/com/pagely/bookservice/application/service/BookCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookCommandService.java
@@ -4,7 +4,9 @@ import com.pagely.bookservice.application.dto.command.CreateBookCommand;
 import com.pagely.bookservice.application.dto.result.BookResult;
 import com.pagely.bookservice.application.port.AladinProvider;
 import com.pagely.bookservice.domain.model.Book;
+import com.pagely.bookservice.domain.model.BookStats;
 import com.pagely.bookservice.domain.repository.BookRepository;
+import com.pagely.bookservice.domain.repository.BookStatsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class BookCommandService {
     private final BookRepository bookRepository;
     private final AladinProvider aladinProvider;
+    private final BookStatsRepository bookStatsRepository;
 
     /**
      * <h1>도서 생성</h1>
@@ -35,9 +38,13 @@ public class BookCommandService {
                     Book.create(item.getId(), item.getTitle(), item.getAuthor(), item.getPublisher(),
                             item.getThumbnailUrl(), item.getDescription(), item.getPublishedAt(),
                             item.getCategoryId(), item.getCategoryName()));
-            log.info("도서 생성");
 
-            // TODO : 도서 통계 엔티티도 생성 해야 됨
+            bookStatsRepository.save(BookStats.builder()
+                    .bookId(command.getId())
+                    .build());
+            log.debug("도서 통계 생성 id: {}", command.getId());
+
+            log.info("도서 생성");
             return BookResult.from(saved);
         } catch (DataIntegrityViolationException e) {
             log.debug("동시 생성 요청으로 중복 발생. id: {}", command.getId());

--- a/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
@@ -9,6 +9,7 @@ import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
 import com.pagely.bookservice.domain.model.BookStats;
 import com.pagely.bookservice.domain.repository.BookLikeRepository;
 import com.pagely.bookservice.domain.repository.BookStatsRepository;
+import com.pagely.bookservice.domain.service.BookLikeDeleteService;
 import com.sun.jdi.request.DuplicateRequestException;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class BookLikeCommandService {
     private final BookGetOrCreateService bookGetOrCreateService;
     private final BookLikeRepository bookLikeRepository;
     private final BookStatsRepository bookStatsRepository;
+    private final BookLikeDeleteService bookLikeDeleteService;
 
     /*
      * 도서 좋아요 생성 메서드
@@ -62,11 +64,10 @@ public class BookLikeCommandService {
     public void deleteBookLike(DeleteBookLikeCommand command) {
         BookLikeId bookLikeId = new BookLikeId(command.getBookId(), command.getUserId());
 
-        if (!bookLikeRepository.existsById(bookLikeId)) {
-            // TODO: 도메인 예외로 수정해야 됨
-            throw new DuplicateRequestException(bookLikeId.toString());
-        }
-        bookLikeRepository.deleteById(bookLikeId);
+        BookLike bookLike = bookLikeRepository.findByBookId(command.getBookId())
+                .orElseThrow(NoSuchElementException::new);
+
+        bookLike.hardDelete(command.getUserId(), bookLikeDeleteService);
 
         BookStats bookStats = bookStatsRepository.findById(command.getBookId())
                 // TODO: 도메인 예외로 수정해야 됨

--- a/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
@@ -1,0 +1,62 @@
+package com.pagely.bookservice.application.service;
+
+import com.pagely.bookservice.application.dto.command.CreateBookCommand;
+import com.pagely.bookservice.application.dto.command.CreateBookLikeCommand;
+import com.pagely.bookservice.application.dto.command.DeleteBookLikeCommand;
+import com.pagely.bookservice.application.dto.result.BookResult;
+import com.pagely.bookservice.domain.model.BookLike;
+import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
+import com.pagely.bookservice.infrastructure.persistence.BookLikeRepositoryAdapter;
+import com.pagely.bookservice.infrastructure.persistence.BookRepositoryAdapter;
+import com.sun.jdi.request.DuplicateRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BookLikeCommandService {
+    private final BookGetOrCreateService bookGetOrCreateService;
+    private final BookLikeRepositoryAdapter bookLikeRepositoryAdapter;
+    private final BookRepositoryAdapter bookRepositoryAdapter;
+
+    /*
+     * 도서 좋아요 생성 메서드
+     *
+     * 도서 서비스는 유저가 상호작용한 도서 정보를 DB에 저장합니다.
+     * 그러므로, 좋아요를 등록하는 시점에 도서 정보가 생성 됩니다.
+     *
+     * 불필요한 외부 api 요청을 줄이기 위해
+     * 도서 정보를 생성하기 전에, 기존에 등록된 좋아요 여부를 먼저 체크합니다.
+     */
+    public void createBookLike(CreateBookLikeCommand command) {
+        BookLikeId bookLikeId = new BookLikeId(command.getBookId(), command.getUserId());
+
+        if (bookLikeRepositoryAdapter.existsById(bookLikeId)) {
+            // TODO: 도메인 예외로 수정해야 됨
+            throw new DuplicateRequestException(bookLikeId.toString());
+        }
+
+        BookResult book = bookGetOrCreateService.getOrCreateBook(CreateBookCommand.builder()
+                .id(bookLikeId.getBookId())
+                .build());
+        bookLikeRepositoryAdapter.save(BookLike.builder()
+                .bookId(bookLikeId.getBookId())
+                .userId(bookLikeId.getUserId())
+                .build());
+        // TODO: BookStats increaseLike 추가 해야 됨
+    }
+
+    public void deleteBookLike(DeleteBookLikeCommand command) {
+        BookLikeId bookLikeId = new BookLikeId(command.getBookId(), command.getUserId());
+
+        if (!bookLikeRepositoryAdapter.existsById(bookLikeId)) {
+            // TODO: 도메인 예외로 수정해야 됨
+            throw new DuplicateRequestException(bookLikeId.toString());
+        }
+        bookLikeRepositoryAdapter.deleteById(bookLikeId);
+        // TODO: BookStats decreaseLike 추가 해야 됨
+    }
+
+}

--- a/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
@@ -6,20 +6,24 @@ import com.pagely.bookservice.application.dto.command.DeleteBookLikeCommand;
 import com.pagely.bookservice.application.dto.result.BookResult;
 import com.pagely.bookservice.domain.model.BookLike;
 import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
-import com.pagely.bookservice.infrastructure.persistence.BookLikeRepositoryAdapter;
-import com.pagely.bookservice.infrastructure.persistence.BookRepositoryAdapter;
+import com.pagely.bookservice.domain.model.BookStats;
+import com.pagely.bookservice.domain.repository.BookLikeRepository;
+import com.pagely.bookservice.domain.repository.BookStatsRepository;
 import com.sun.jdi.request.DuplicateRequestException;
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class BookLikeCommandService {
     private final BookGetOrCreateService bookGetOrCreateService;
-    private final BookLikeRepositoryAdapter bookLikeRepositoryAdapter;
-    private final BookRepositoryAdapter bookRepositoryAdapter;
+    private final BookLikeRepository bookLikeRepository;
+    private final BookStatsRepository bookStatsRepository;
 
     /*
      * 도서 좋아요 생성 메서드
@@ -33,7 +37,7 @@ public class BookLikeCommandService {
     public void createBookLike(CreateBookLikeCommand command) {
         BookLikeId bookLikeId = new BookLikeId(command.getBookId(), command.getUserId());
 
-        if (bookLikeRepositoryAdapter.existsById(bookLikeId)) {
+        if (bookLikeRepository.existsById(bookLikeId)) {
             // TODO: 도메인 예외로 수정해야 됨
             throw new DuplicateRequestException(bookLikeId.toString());
         }
@@ -41,22 +45,36 @@ public class BookLikeCommandService {
         BookResult book = bookGetOrCreateService.getOrCreateBook(CreateBookCommand.builder()
                 .id(bookLikeId.getBookId())
                 .build());
-        bookLikeRepositoryAdapter.save(BookLike.builder()
+        bookLikeRepository.save(BookLike.builder()
                 .bookId(bookLikeId.getBookId())
                 .userId(bookLikeId.getUserId())
                 .build());
-        // TODO: BookStats increaseLike 추가 해야 됨
+
+        BookStats bookStats = bookStatsRepository.findById(command.getBookId())
+                // TODO: 도메인 예외로 수정해야 됨
+                .orElseThrow(NoSuchElementException::new);
+        bookStats.increaseLikeCount();
+
+        log.debug("도서 통계 좋아요 갯수 증가 id: {}", command.getBookId());
+        log.info("도서 좋아요 생성");
     }
 
     public void deleteBookLike(DeleteBookLikeCommand command) {
         BookLikeId bookLikeId = new BookLikeId(command.getBookId(), command.getUserId());
 
-        if (!bookLikeRepositoryAdapter.existsById(bookLikeId)) {
+        if (!bookLikeRepository.existsById(bookLikeId)) {
             // TODO: 도메인 예외로 수정해야 됨
             throw new DuplicateRequestException(bookLikeId.toString());
         }
-        bookLikeRepositoryAdapter.deleteById(bookLikeId);
-        // TODO: BookStats decreaseLike 추가 해야 됨
+        bookLikeRepository.deleteById(bookLikeId);
+
+        BookStats bookStats = bookStatsRepository.findById(command.getBookId())
+                // TODO: 도메인 예외로 수정해야 됨
+                .orElseThrow(NoSuchElementException::new);
+        bookStats.decreaseLikeCount();
+
+        log.debug("도서 통계 좋아요 갯수 감소 id: {}", command.getBookId());
+        log.info("도서 좋아요 삭제");
     }
 
 }

--- a/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
@@ -64,10 +64,10 @@ public class BookLikeCommandService {
     public void deleteBookLike(DeleteBookLikeCommand command) {
         BookLikeId bookLikeId = new BookLikeId(command.getBookId(), command.getUserId());
 
-        BookLike bookLike = bookLikeRepository.findByBookId(command.getBookId())
+        BookLike bookLike = bookLikeRepository.findById(bookLikeId)
                 .orElseThrow(NoSuchElementException::new);
 
-        bookLike.hardDelete(command.getUserId(), bookLikeDeleteService);
+        bookLike.hardDelete(bookLikeId, bookLikeDeleteService);
 
         BookStats bookStats = bookStatsRepository.findById(command.getBookId())
                 // TODO: 도메인 예외로 수정해야 됨

--- a/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
+++ b/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
@@ -61,7 +61,7 @@ public class BookLike {
         this.userId = userId;
     }
 
-    public void hardDelete(UUID requester, BookLikeDeleteService bookLikeDeleteService) {
+    public void hardDelete(BookLikeId requester, BookLikeDeleteService bookLikeDeleteService) {
         bookLikeDeleteService.deleteBookLike(this, requester);
     }
 

--- a/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
+++ b/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
@@ -1,5 +1,6 @@
 package com.pagely.bookservice.domain.model;
 
+import com.pagely.bookservice.domain.service.BookLikeDeleteService;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -58,6 +59,10 @@ public class BookLike {
     public BookLike(String bookId, UUID userId) {
         this.bookId = bookId;
         this.userId = userId;
+    }
+
+    public void hardDelete(UUID requester, BookLikeDeleteService bookLikeDeleteService) {
+        bookLikeDeleteService.deleteBookLike(this, requester);
     }
 
     @Getter

--- a/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
+++ b/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
@@ -18,13 +18,25 @@ import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+/**
+ * <h1>좋아요</h1>
+ * <p>
+ * 도서 좋아요는 도서의 id를 참조하지만 FK 제약 조건이 걸려있지 않는 설계
+ * <p>
+ * 이유
+ * <ul>
+ *     <li>도서 삭제는 현재 비즈니스 로직 상 존재하지않음</li>
+ *     <li>도서가 삭제 된다면 인적 오류로, 언제든지 외부 api를 통해 도서 정보 복구 가능</li>
+ *     <li>ISBN을 key 값으로 사용하기에 어떤 경로를 통해서 도서 정보를 받아오더라도 같은 도서임이 보증됨</li>
+ * </ul>
+ */
 @Entity
 @Table(name = "p_book_like")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @IdClass(BookLike.BookLikeId.class)
 @EntityListeners(AuditingEntityListener.class)
-public class BookLike implements Serializable {
+public class BookLike {
 
     @Id
     @Column(name = "book_id", nullable = false, length = 20)

--- a/src/main/java/com/pagely/bookservice/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/pagely/bookservice/domain/repository/BookLikeRepository.java
@@ -2,6 +2,7 @@ package com.pagely.bookservice.domain.repository;
 
 import com.pagely.bookservice.domain.model.BookLike;
 import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
+import java.util.Optional;
 
 public interface BookLikeRepository {
     boolean existsById(BookLikeId bookLikeId);
@@ -9,4 +10,6 @@ public interface BookLikeRepository {
     BookLike save(BookLike bookLike);
 
     void deleteById(BookLikeId bookLikeId);
+
+    Optional<BookLike> findByBookId(String bookId);
 }

--- a/src/main/java/com/pagely/bookservice/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/pagely/bookservice/domain/repository/BookLikeRepository.java
@@ -1,0 +1,12 @@
+package com.pagely.bookservice.domain.repository;
+
+import com.pagely.bookservice.domain.model.BookLike;
+import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
+
+public interface BookLikeRepository {
+    boolean existsById(BookLikeId bookLikeId);
+
+    BookLike save(BookLike bookLike);
+
+    void deleteById(BookLikeId bookLikeId);
+}

--- a/src/main/java/com/pagely/bookservice/domain/repository/BookLikeRepository.java
+++ b/src/main/java/com/pagely/bookservice/domain/repository/BookLikeRepository.java
@@ -11,5 +11,5 @@ public interface BookLikeRepository {
 
     void deleteById(BookLikeId bookLikeId);
 
-    Optional<BookLike> findByBookId(String bookId);
+    Optional<BookLike> findById(BookLikeId bookLike);
 }

--- a/src/main/java/com/pagely/bookservice/domain/repository/BookStatsRepository.java
+++ b/src/main/java/com/pagely/bookservice/domain/repository/BookStatsRepository.java
@@ -1,0 +1,10 @@
+package com.pagely.bookservice.domain.repository;
+
+import com.pagely.bookservice.domain.model.BookStats;
+import java.util.Optional;
+
+public interface BookStatsRepository {
+    Optional<BookStats> findById(String bookId);
+
+    BookStats save(BookStats bookStats);
+}

--- a/src/main/java/com/pagely/bookservice/domain/service/BookLikeDeleteService.java
+++ b/src/main/java/com/pagely/bookservice/domain/service/BookLikeDeleteService.java
@@ -3,7 +3,6 @@ package com.pagely.bookservice.domain.service;
 import com.pagely.bookservice.domain.model.BookLike;
 import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
 import com.pagely.bookservice.domain.repository.BookLikeRepository;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -15,12 +14,13 @@ public class BookLikeDeleteService {
     private final BookLikeRepository bookLikeRepository;
 
     // TODO: Role 추가 시, 관리자는 무조건 삭제할 수 있도록 수정
-    public void deleteBookLike(BookLike bookLike, UUID requester) {
-        if (!bookLike.getUserId().equals(requester)) {
+    public void deleteBookLike(BookLike bookLike, BookLikeId requester) {
+        if (!bookLike.getUserId().equals(requester.getUserId())
+                || !bookLike.getBookId().equals(requester.getBookId())) {
             log.debug("좋아요 생성 유저: {} , 요청 유저: {}", bookLike.getUserId(), requester);
             // TODO: 도메인 예외로 수정해야 함
             throw new IllegalArgumentException();
         }
-        bookLikeRepository.deleteById(new BookLikeId(bookLike.getBookId(), bookLike.getUserId()));
+        bookLikeRepository.deleteById(requester);
     }
 }

--- a/src/main/java/com/pagely/bookservice/domain/service/BookLikeDeleteService.java
+++ b/src/main/java/com/pagely/bookservice/domain/service/BookLikeDeleteService.java
@@ -1,0 +1,26 @@
+package com.pagely.bookservice.domain.service;
+
+import com.pagely.bookservice.domain.model.BookLike;
+import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
+import com.pagely.bookservice.domain.repository.BookLikeRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class BookLikeDeleteService {
+    private final BookLikeRepository bookLikeRepository;
+
+    // TODO: Role 추가 시, 관리자는 무조건 삭제할 수 있도록 수정
+    public void deleteBookLike(BookLike bookLike, UUID requester) {
+        if (!bookLike.getUserId().equals(requester)) {
+            log.debug("좋아요 생성 유저: {} , 요청 유저: {}", bookLike.getUserId(), requester);
+            // TODO: 도메인 예외로 수정해야 함
+            throw new IllegalArgumentException();
+        }
+        bookLikeRepository.deleteById(new BookLikeId(bookLike.getBookId(), bookLike.getUserId()));
+    }
+}

--- a/src/main/java/com/pagely/bookservice/global/config/AsyncConfig.java
+++ b/src/main/java/com/pagely/bookservice/global/config/AsyncConfig.java
@@ -3,11 +3,9 @@ package com.pagely.bookservice.global.config;
 import java.util.concurrent.Executor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
-@EnableAsync
 public class AsyncConfig {
     @Bean(name = "bookGeneratorExecutor")
     public Executor bookGeneratorExecutor() {

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookLikeRepositoryAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookLikeRepositoryAdapter.java
@@ -28,8 +28,8 @@ public class BookLikeRepositoryAdapter implements BookLikeRepository {
     }
 
     @Override
-    public Optional<BookLike> findByBookId(String bookId) {
-        return jpaBookLikeRepository.findByBookId(bookId);
+    public Optional<BookLike> findById(BookLikeId bookLikeId) {
+        return jpaBookLikeRepository.findById(bookLikeId);
     }
-    
+
 }

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookLikeRepositoryAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookLikeRepositoryAdapter.java
@@ -3,6 +3,7 @@ package com.pagely.bookservice.infrastructure.persistence;
 import com.pagely.bookservice.domain.model.BookLike;
 import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
 import com.pagely.bookservice.domain.repository.BookLikeRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -25,4 +26,10 @@ public class BookLikeRepositoryAdapter implements BookLikeRepository {
     public void deleteById(BookLikeId bookLikeId) {
         jpaBookLikeRepository.deleteById(bookLikeId);
     }
+
+    @Override
+    public Optional<BookLike> findByBookId(String bookId) {
+        return jpaBookLikeRepository.findByBookId(bookId);
+    }
+    
 }

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookLikeRepositoryAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookLikeRepositoryAdapter.java
@@ -1,0 +1,28 @@
+package com.pagely.bookservice.infrastructure.persistence;
+
+import com.pagely.bookservice.domain.model.BookLike;
+import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
+import com.pagely.bookservice.domain.repository.BookLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookLikeRepositoryAdapter implements BookLikeRepository {
+    private final JpaBookLikeRepository jpaBookLikeRepository;
+
+    @Override
+    public boolean existsById(BookLikeId bookLikeId) {
+        return jpaBookLikeRepository.existsById(bookLikeId);
+    }
+
+    @Override
+    public BookLike save(BookLike bookLike) {
+        return jpaBookLikeRepository.save(bookLike);
+    }
+
+    @Override
+    public void deleteById(BookLikeId bookLikeId) {
+        jpaBookLikeRepository.deleteById(bookLikeId);
+    }
+}

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookStatsRepositoryAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/BookStatsRepositoryAdapter.java
@@ -1,0 +1,23 @@
+package com.pagely.bookservice.infrastructure.persistence;
+
+import com.pagely.bookservice.domain.model.BookStats;
+import com.pagely.bookservice.domain.repository.BookStatsRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class BookStatsRepositoryAdapter implements BookStatsRepository {
+    private final JpaBookStatsRepository jpaBookStatsRepository;
+
+    @Override
+    public Optional<BookStats> findById(String bookId) {
+        return jpaBookStatsRepository.findById(bookId);
+    }
+
+    @Override
+    public BookStats save(BookStats bookStats) {
+        return jpaBookStatsRepository.save(bookStats);
+    }
+}

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookLikeRepository.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookLikeRepository.java
@@ -2,9 +2,7 @@ package com.pagely.bookservice.infrastructure.persistence;
 
 import com.pagely.bookservice.domain.model.BookLike;
 import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaBookLikeRepository extends JpaRepository<BookLike, BookLikeId> {
-    Optional<BookLike> findByBookId(String bookId);
 }

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookLikeRepository.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookLikeRepository.java
@@ -1,0 +1,8 @@
+package com.pagely.bookservice.infrastructure.persistence;
+
+import com.pagely.bookservice.domain.model.BookLike;
+import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaBookLikeRepository extends JpaRepository<BookLike, BookLikeId> {
+}

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookLikeRepository.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookLikeRepository.java
@@ -2,7 +2,9 @@ package com.pagely.bookservice.infrastructure.persistence;
 
 import com.pagely.bookservice.domain.model.BookLike;
 import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaBookLikeRepository extends JpaRepository<BookLike, BookLikeId> {
+    Optional<BookLike> findByBookId(String bookId);
 }

--- a/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookStatsRepository.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/persistence/JpaBookStatsRepository.java
@@ -1,0 +1,7 @@
+package com.pagely.bookservice.infrastructure.persistence;
+
+import com.pagely.bookservice.domain.model.BookStats;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaBookStatsRepository extends JpaRepository<BookStats, String> {
+}

--- a/src/main/java/com/pagely/bookservice/presentation/controller/BookController.java
+++ b/src/main/java/com/pagely/bookservice/presentation/controller/BookController.java
@@ -1,16 +1,46 @@
 package com.pagely.bookservice.presentation.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
+import com.pagely.bookservice.application.dto.command.CreateBookLikeCommand;
+import com.pagely.bookservice.application.dto.command.DeleteBookLikeCommand;
+import com.pagely.bookservice.application.service.BookLikeCommandService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequestMapping("/api/v1/books")
 @RestController
+@RequiredArgsConstructor
 public class BookController {
+    private final BookLikeCommandService bookLikeCommandService;
 
-    @GetMapping
-    String hello() {
-        return "HelloWorld!";
+    @PostMapping("/{bookId}/like")
+    public ResponseEntity<Void> addLike(
+            @PathVariable String bookId,
+            @RequestHeader("X-User-Id") UUID userId
+    ) {
+        bookLikeCommandService.createBookLike(CreateBookLikeCommand.builder()
+                .bookId(bookId)
+                .userId(userId)
+                .build());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
+    @DeleteMapping("/{bookId}/like")
+    public ResponseEntity<Void> removeLike(
+            @PathVariable String bookId,
+            @RequestHeader("X-User-Id") UUID userId
+    ) {
+        bookLikeCommandService.deleteBookLike(DeleteBookLikeCommand.builder()
+                .bookId(bookId)
+                .userId(userId)
+                .build());
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ server:
 
 spring:
   config:
-    import: optional:file:book-service/.env[.properties]
+    import: optional:classpath:/.env[.properties]
 
   application:
     name: bookservice


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 도서 좋아요 기능 구현
- 좋아요 생성 시 도서 통계에 내용 반영
- 중복 선언된 `@EnableAsync` 애노테이션 삭제

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #9 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] 도서 좋아요 API 구현
- [x] 도서 통계에 좋아요 반영

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="680" height="378" alt="image" src="https://github.com/user-attachments/assets/490260af-179a-4b78-b919-2149c22b78a7" />

- 좋아요 등록 요청 시 응답

<img width="446" height="97" alt="image" src="https://github.com/user-attachments/assets/88f2c48a-3230-442d-9ac0-534838fbac9d" />

- 좋아요 취소 요청 시


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
- 좋아요 취소는 예외적으로 `hard delete` 를 허용
  - 삭제 프로세스 일치를 위해, domain service 정의 후 도메인 엔티티에서 `hardDelete()` 메서드를 호출하도록 구현
- DTO -> record 리팩토링 관련 이슈 발행

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 도서에 좋아요를 추가/제거하는 REST API 엔드포인트를 추가했습니다 (POST/DELETE /api/v1/books/{bookId}/like).
  * 요청 시 X-User-Id 헤더로 사용자 식별을 받아 좋아요를 처리합니다.

* **개선 사항**
  * 도서 생성 시 도서별 통계(좋아요 등)를 자동으로 생성·저장합니다.
  * 좋아요 요청에 대한 입력 검증(도서 ID 길이 제한·사용자 ID 필수)을 적용했습니다.

* **버그 수정**
  * 삭제 권한 검증을 강화해 잘못된 삭제 시 예외를 발생시킵니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->