### PR TITLE
[FEAT] 좋아요 등록/취소 이벤트 발행 구현

### DIFF
--- a/src/main/java/com/pagely/bookservice/application/event/BookEventHandler.java
+++ b/src/main/java/com/pagely/bookservice/application/event/BookEventHandler.java
@@ -1,7 +1,13 @@
 package com.pagely.bookservice.application.event;
 
 import com.pagely.bookservice.domain.event.payload.BookCreatedEvent;
+import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
+import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
 
 public interface BookEventHandler {
     void handleBookCreated(BookCreatedEvent event);
+
+    void handleBookLiked(BookLikedEvent event);
+
+    void handleBookUnliked(BookUnlikedEvent event);
 }

--- a/src/main/java/com/pagely/bookservice/application/port/out/BookLikeEventPort.java
+++ b/src/main/java/com/pagely/bookservice/application/port/out/BookLikeEventPort.java
@@ -1,0 +1,10 @@
+package com.pagely.bookservice.application.port.out;
+
+import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
+import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
+
+public interface BookLikeEventPort {
+    void publishBookLiked(BookLikedEvent event);
+
+    void publishBookUnliked(BookUnlikedEvent event);
+}

--- a/src/main/java/com/pagely/bookservice/application/service/BookCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookCommandService.java
@@ -35,6 +35,10 @@ public class BookCommandService {
      * </ul>
      */
     public BookResult createBook(CreateBookCommand command) {
+        return BookResult.from(createBookEntity(command));
+    }
+
+    public Book createBookEntity(CreateBookCommand command) {
         BookResult item = aladinProvider.getItem(command.bookId());
         try {
             Book saved = bookRepository.save(
@@ -45,14 +49,12 @@ public class BookCommandService {
             bookStatsRepository.save(BookStats.builder()
                     .bookId(command.bookId())
                     .build());
-            log.debug("도서 통계 생성 bookId: {}", command.bookId());
 
-            log.info("도서 생성");
-            return BookResult.from(saved);
+            return saved;
         } catch (DataIntegrityViolationException e) {
             log.debug("동시 생성 요청으로 중복 발생. bookId: {}", command.bookId());
-            return BookResult.from(bookRepository.findById(command.bookId())
-                    .orElseThrow(NotFoundBookException::new));
+            return bookRepository.findById(command.bookId())
+                    .orElseThrow(NotFoundBookException::new);
         }
     }
 }

--- a/src/main/java/com/pagely/bookservice/application/service/BookGetOrCreateService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookGetOrCreateService.java
@@ -2,6 +2,8 @@ package com.pagely.bookservice.application.service;
 
 import com.pagely.bookservice.application.dto.command.CreateBookCommand;
 import com.pagely.bookservice.application.dto.result.BookResult;
+import com.pagely.bookservice.domain.exception.detail.NotFoundBookException;
+import com.pagely.bookservice.domain.model.Book;
 import com.pagely.bookservice.domain.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,6 +18,7 @@ public class BookGetOrCreateService {
     private final BookCommandService bookCommandService;
     private final BookRepository bookRepository;
 
+    // API 응답용
     public BookResult getOrCreateBook(CreateBookCommand command) {
         log.debug("도서 조회 요청");
         return bookRepository.findById(command.bookId())
@@ -26,5 +29,15 @@ public class BookGetOrCreateService {
                             return bookCommandService.createBook(command);
                         }
                 );
+    }
+
+    // 내부 로직용 — Book 엔티티 반환
+    public Book getOrCreateBookEntity(String bookId) {
+        return bookRepository.findById(bookId)
+                .orElseGet(() -> {
+                    bookCommandService.createBook(new CreateBookCommand(bookId));
+                    return bookRepository.findById(bookId)
+                            .orElseThrow(NotFoundBookException::new);
+                });
     }
 }

--- a/src/main/java/com/pagely/bookservice/application/service/BookGetOrCreateService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookGetOrCreateService.java
@@ -2,7 +2,6 @@ package com.pagely.bookservice.application.service;
 
 import com.pagely.bookservice.application.dto.command.CreateBookCommand;
 import com.pagely.bookservice.application.dto.result.BookResult;
-import com.pagely.bookservice.domain.exception.detail.NotFoundBookException;
 import com.pagely.bookservice.domain.model.Book;
 import com.pagely.bookservice.domain.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,24 +19,20 @@ public class BookGetOrCreateService {
 
     // API 응답용
     public BookResult getOrCreateBook(CreateBookCommand command) {
-        log.debug("도서 조회 요청");
         return bookRepository.findById(command.bookId())
                 .map(BookResult::from)
-                .orElseGet(
-                        () -> {
-                            log.debug("도서가 DB에 존재하지않아 외부 요청 후 도서 정보를 생성합니다. bookId: {}", command.bookId());
-                            return bookCommandService.createBook(command);
-                        }
-                );
+                .orElseGet(() -> {
+                    log.debug("도서가 DB에 존재하지않아 외부 요청 후 도서 정보를 생성합니다. bookId: {}", command.bookId());
+                    return bookCommandService.createBook(command);
+                });
     }
 
     // 내부 로직용 — Book 엔티티 반환
-    public Book getOrCreateBookEntity(String bookId) {
-        return bookRepository.findById(bookId)
+    public Book getOrCreateBookEntity(CreateBookCommand command) {
+        return bookRepository.findById(command.bookId())
                 .orElseGet(() -> {
-                    bookCommandService.createBook(new CreateBookCommand(bookId));
-                    return bookRepository.findById(bookId)
-                            .orElseThrow(NotFoundBookException::new);
+                    log.debug("도서가 DB에 존재하지않아 외부 요청 후 도서 정보를 생성합니다. bookId: {}", command.bookId());
+                    return bookCommandService.createBookEntity(command);
                 });
     }
 }

--- a/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
@@ -1,5 +1,6 @@
 package com.pagely.bookservice.application.service;
 
+import com.pagely.bookservice.application.dto.command.CreateBookCommand;
 import com.pagely.bookservice.application.dto.command.CreateBookLikeCommand;
 import com.pagely.bookservice.application.dto.command.DeleteBookLikeCommand;
 import com.pagely.bookservice.domain.event.BookEvents;
@@ -45,7 +46,7 @@ public class BookLikeCommandService {
             throw new DuplicatedBookLikeException();
         }
 
-        Book book = bookGetOrCreateService.getOrCreateBookEntity(command.bookId());
+        Book book = bookGetOrCreateService.getOrCreateBookEntity(new CreateBookCommand(command.bookId()));
 
         bookLikeRepository.save(BookLike.create(book, command.userId(), bookEvents));
 
@@ -63,7 +64,7 @@ public class BookLikeCommandService {
         BookLike bookLike = bookLikeRepository.findById(bookLikeId)
                 .orElseThrow(NotFoundLikeException::new);
 
-        Book book = bookGetOrCreateService.getOrCreateBookEntity(command.bookId());
+        Book book = bookGetOrCreateService.getOrCreateBookEntity(new CreateBookCommand(command.bookId()));
         bookLike.hardDelete(book, bookLikeId, bookLikeDeleteService, bookEvents);
 
         BookStats bookStats = bookStatsRepository.findById(command.bookId())

--- a/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
+++ b/src/main/java/com/pagely/bookservice/application/service/BookLikeCommandService.java
@@ -1,12 +1,12 @@
 package com.pagely.bookservice.application.service;
 
-import com.pagely.bookservice.application.dto.command.CreateBookCommand;
 import com.pagely.bookservice.application.dto.command.CreateBookLikeCommand;
 import com.pagely.bookservice.application.dto.command.DeleteBookLikeCommand;
-import com.pagely.bookservice.application.dto.result.BookResult;
+import com.pagely.bookservice.domain.event.BookEvents;
 import com.pagely.bookservice.domain.exception.detail.DuplicatedBookLikeException;
 import com.pagely.bookservice.domain.exception.detail.NotFoundLikeException;
 import com.pagely.bookservice.domain.exception.detail.NotFoundStatsException;
+import com.pagely.bookservice.domain.model.Book;
 import com.pagely.bookservice.domain.model.BookLike;
 import com.pagely.bookservice.domain.model.BookLike.BookLikeId;
 import com.pagely.bookservice.domain.model.BookStats;
@@ -27,6 +27,7 @@ public class BookLikeCommandService {
     private final BookLikeRepository bookLikeRepository;
     private final BookStatsRepository bookStatsRepository;
     private final BookLikeDeleteService bookLikeDeleteService;
+    private final BookEvents bookEvents;
 
     /*
      * 도서 좋아요 생성 메서드
@@ -44,11 +45,9 @@ public class BookLikeCommandService {
             throw new DuplicatedBookLikeException();
         }
 
-        BookResult book = bookGetOrCreateService.getOrCreateBook(new CreateBookCommand(bookLikeId.getBookId()));
-        bookLikeRepository.save(BookLike.builder()
-                .bookId(bookLikeId.getBookId())
-                .userId(bookLikeId.getUserId())
-                .build());
+        Book book = bookGetOrCreateService.getOrCreateBookEntity(command.bookId());
+
+        bookLikeRepository.save(BookLike.create(book, command.userId(), bookEvents));
 
         BookStats bookStats = bookStatsRepository.findById(command.bookId())
                 .orElseThrow(NotFoundStatsException::new);
@@ -64,7 +63,8 @@ public class BookLikeCommandService {
         BookLike bookLike = bookLikeRepository.findById(bookLikeId)
                 .orElseThrow(NotFoundLikeException::new);
 
-        bookLike.hardDelete(bookLikeId, bookLikeDeleteService);
+        Book book = bookGetOrCreateService.getOrCreateBookEntity(command.bookId());
+        bookLike.hardDelete(book, bookLikeId, bookLikeDeleteService, bookEvents);
 
         BookStats bookStats = bookStatsRepository.findById(command.bookId())
                 .orElseThrow(NotFoundStatsException::new);

--- a/src/main/java/com/pagely/bookservice/domain/event/BookEvents.java
+++ b/src/main/java/com/pagely/bookservice/domain/event/BookEvents.java
@@ -1,7 +1,13 @@
 package com.pagely.bookservice.domain.event;
 
 import com.pagely.bookservice.domain.event.payload.BookCreatedEvent;
+import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
+import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
 
 public interface BookEvents {
     void bookCreated(BookCreatedEvent event);
+
+    void bookLiked(BookLikedEvent event);
+
+    void bookUnliked(BookUnlikedEvent event);
 }

--- a/src/main/java/com/pagely/bookservice/domain/event/payload/BookLikedEvent.java
+++ b/src/main/java/com/pagely/bookservice/domain/event/payload/BookLikedEvent.java
@@ -1,0 +1,30 @@
+package com.pagely.bookservice.domain.event.payload;
+
+import com.pagely.bookservice.domain.event.BaseEvent;
+import com.pagely.bookservice.domain.model.Book;
+import com.pagely.bookservice.domain.model.BookLike;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class BookLikedEvent extends BaseEvent {
+    private static final String DOMAIN_TYPE = "BOOK_LIKE";
+
+    private BookLikedEvent(String bookId, Object payload) {
+        super(DOMAIN_TYPE, bookId, payload);
+    }
+
+    public static BookLikedEvent of(BookLike bookLike, Book book) {
+        return new BookLikedEvent(
+                book.getId(),
+                new BookLikedEvent.Payload(
+                        bookLike.getUserId(),
+                        book.getId(), book.getTitle(),
+                        book.getCategory().getName(),
+                        book.getDescription(), book.getAuthors()));
+    }
+
+    public record Payload(UUID userId, String bookId, String title, String category, String description,
+                          String authors) {
+    }
+}

--- a/src/main/java/com/pagely/bookservice/domain/event/payload/BookUnlikedEvent.java
+++ b/src/main/java/com/pagely/bookservice/domain/event/payload/BookUnlikedEvent.java
@@ -1,0 +1,30 @@
+package com.pagely.bookservice.domain.event.payload;
+
+import com.pagely.bookservice.domain.event.BaseEvent;
+import com.pagely.bookservice.domain.model.Book;
+import com.pagely.bookservice.domain.model.BookLike;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class BookUnlikedEvent extends BaseEvent {
+    private static final String DOMAIN_TYPE = "BOOK_LIKE";
+
+    private BookUnlikedEvent(String bookId, Object payload) {
+        super(DOMAIN_TYPE, bookId, payload);
+    }
+
+    public static BookUnlikedEvent of(BookLike bookLike, Book book) {
+        return new BookUnlikedEvent(
+                book.getId(),
+                new BookUnlikedEvent.Payload(
+                        bookLike.getUserId(),
+                        book.getId(), book.getTitle(),
+                        book.getCategory().getName(),
+                        book.getDescription(), book.getAuthors()));
+    }
+
+    public record Payload(UUID userId, String bookId, String title, String category, String description,
+                          String authors) {
+    }
+}

--- a/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
+++ b/src/main/java/com/pagely/bookservice/domain/model/BookLike.java
@@ -1,5 +1,8 @@
 package com.pagely.bookservice.domain.model;
 
+import com.pagely.bookservice.domain.event.BookEvents;
+import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
+import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
 import com.pagely.bookservice.domain.service.BookLikeDeleteService;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -55,14 +58,29 @@ public class BookLike {
     @Column(name = "created_by", nullable = false, updatable = false)
     private UUID createdBy;
 
-    @Builder
-    public BookLike(String bookId, UUID userId) {
+    @Builder(access = AccessLevel.PRIVATE)
+    private BookLike(String bookId, UUID userId) {
         this.bookId = bookId;
         this.userId = userId;
     }
 
-    public void hardDelete(BookLikeId requester, BookLikeDeleteService bookLikeDeleteService) {
-        bookLikeDeleteService.deleteBookLike(this, requester);
+    public static BookLike create(Book book, UUID userId, BookEvents events) {
+        BookLike like = BookLike.builder()
+                .userId(userId)
+                .bookId(book.getId())
+                .build();
+
+        events.bookLiked(BookLikedEvent.of(like, book));
+
+        return like;
+    }
+
+
+    public void hardDelete(Book book, BookLikeId bookLikeId, BookLikeDeleteService bookLikeDeleteService,
+                           BookEvents events) {
+        bookLikeDeleteService.deleteBookLike(this, bookLikeId);
+
+        events.bookUnliked(BookUnlikedEvent.of(this, book));
     }
 
     @Getter

--- a/src/main/java/com/pagely/bookservice/infrastructure/evnet/BookEventHandlerAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/evnet/BookEventHandlerAdapter.java
@@ -2,7 +2,10 @@ package com.pagely.bookservice.infrastructure.evnet;
 
 import com.pagely.bookservice.application.event.BookEventHandler;
 import com.pagely.bookservice.application.port.out.BookEventPort;
+import com.pagely.bookservice.application.port.out.BookLikeEventPort;
 import com.pagely.bookservice.domain.event.payload.BookCreatedEvent;
+import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
+import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -13,10 +16,23 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class BookEventHandlerAdapter implements BookEventHandler {
 
     private final BookEventPort bookEventPort;
+    private final BookLikeEventPort bookLikeEventPort;
 
     @Override
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleBookCreated(BookCreatedEvent event) {
         bookEventPort.publishBookCreated(event);
+    }
+
+    @Override
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleBookLiked(BookLikedEvent event) {
+        bookLikeEventPort.publishBookLiked(event);
+    }
+
+    @Override
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleBookUnliked(BookUnlikedEvent event) {
+        bookLikeEventPort.publishBookUnliked(event);
     }
 }

--- a/src/main/java/com/pagely/bookservice/infrastructure/evnet/SpringBookEventPublisher.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/evnet/SpringBookEventPublisher.java
@@ -2,18 +2,30 @@ package com.pagely.bookservice.infrastructure.evnet;
 
 import com.pagely.bookservice.domain.event.BookEvents;
 import com.pagely.bookservice.domain.event.payload.BookCreatedEvent;
+import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
+import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class SpringEventPublisher implements BookEvents {
+public class SpringBookEventPublisher implements BookEvents {
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     public void bookCreated(BookCreatedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void bookLiked(BookLikedEvent event) {
+        applicationEventPublisher.publishEvent(event);
+    }
+
+    @Override
+    public void bookUnliked(BookUnlikedEvent event) {
         applicationEventPublisher.publishEvent(event);
     }
 }

--- a/src/main/java/com/pagely/bookservice/infrastructure/messaging/kafka/producer/KafkaBookEventAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/messaging/kafka/producer/KafkaBookEventAdapter.java
@@ -3,9 +3,11 @@ package com.pagely.bookservice.infrastructure.messaging.kafka.producer;
 import com.pagely.bookservice.application.port.out.BookEventPort;
 import com.pagely.bookservice.domain.event.payload.BookCreatedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KafkaBookEventAdapter implements BookEventPort {
@@ -15,8 +17,18 @@ public class KafkaBookEventAdapter implements BookEventPort {
 
     @Override
     public void publishBookCreated(BookCreatedEvent event) {
-        kafkaTemplate.send(BOOK_CREATED_TOPIC,
-                event.getDomainId(),
-                event);
+        publish(BOOK_CREATED_TOPIC, event.getDomainId(), event);
+    }
+
+    private void publish(String topic, String key, Object event) {
+        kafkaTemplate.send(topic, key, event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 발행 실패 topic: {} key: {}", topic, key, ex);
+                    } else {
+                        log.info("Kafka 발행 성공 topic: {} key: {} offset: {}",
+                                topic, key, result.getRecordMetadata().offset());
+                    }
+                });
     }
 }

--- a/src/main/java/com/pagely/bookservice/infrastructure/messaging/kafka/producer/KafkaBookLikeEventAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/messaging/kafka/producer/KafkaBookLikeEventAdapter.java
@@ -1,0 +1,31 @@
+package com.pagely.bookservice.infrastructure.messaging.kafka.producer;
+
+import com.pagely.bookservice.application.port.out.BookLikeEventPort;
+import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
+import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaBookLikeEventAdapter implements BookLikeEventPort {
+    private static final String BOOK_LIKED_TOPIC = "book-liked";
+    private static final String BOOK_UNLIKED_TOPIC = "book-unliked";
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void publishBookLiked(BookLikedEvent event) {
+        kafkaTemplate.send(BOOK_LIKED_TOPIC,
+                event.getDomainId(),
+                event);
+    }
+
+    @Override
+    public void publishBookUnliked(BookUnlikedEvent event) {
+        kafkaTemplate.send(BOOK_UNLIKED_TOPIC,
+                event.getDomainId(),
+                event);
+    }
+}

--- a/src/main/java/com/pagely/bookservice/infrastructure/messaging/kafka/producer/KafkaBookLikeEventAdapter.java
+++ b/src/main/java/com/pagely/bookservice/infrastructure/messaging/kafka/producer/KafkaBookLikeEventAdapter.java
@@ -4,9 +4,11 @@ import com.pagely.bookservice.application.port.out.BookLikeEventPort;
 import com.pagely.bookservice.domain.event.payload.BookLikedEvent;
 import com.pagely.bookservice.domain.event.payload.BookUnlikedEvent;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class KafkaBookLikeEventAdapter implements BookLikeEventPort {
@@ -17,15 +19,23 @@ public class KafkaBookLikeEventAdapter implements BookLikeEventPort {
 
     @Override
     public void publishBookLiked(BookLikedEvent event) {
-        kafkaTemplate.send(BOOK_LIKED_TOPIC,
-                event.getDomainId(),
-                event);
+        publish(BOOK_LIKED_TOPIC, event.getDomainId(), event);
     }
 
     @Override
     public void publishBookUnliked(BookUnlikedEvent event) {
-        kafkaTemplate.send(BOOK_UNLIKED_TOPIC,
-                event.getDomainId(),
-                event);
+        publish(BOOK_UNLIKED_TOPIC, event.getDomainId(), event);
+    }
+
+    private void publish(String topic, String key, Object event) {
+        kafkaTemplate.send(topic, key, event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("Kafka 발행 실패 topic: {} key: {}", topic, key, ex);
+                    } else {
+                        log.info("Kafka 발행 성공 topic: {} key: {} offset: {}",
+                                topic, key, result.getRecordMetadata().offset());
+                    }
+                });
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 도서 좋아요 등록/취소 이벤트 발행 구현
- 도서 조회 내부(entity 반환),외부(api 전용) 메서드 분리

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #17 
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [ ] 좋아요 등록 이벤트 발행
- [ ] 좋아요 취소 이벤트 발행

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.

<img width="649" height="378" alt="image" src="https://github.com/user-attachments/assets/177e461a-040b-4d7d-be4a-e885556e77ad" />

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 도서 '좋아요' / '좋아요 취소' 도메인 이벤트 타입 및 페이로드가 추가되어 좋아요 상태 변경이 이벤트로 발행됩니다.
  * 좋아요 관련 이벤트를 Kafka로 전송하는 퍼블리셔와 어댑터가 도입되어 메시징 전파가 가능합니다.

* **Refactor**
  * 좋아요 생성·삭제 흐름이 이벤트 중심으로 재구성되어 생성/삭제 시 이벤트 발행이 표준화되고 핸들러가 이벤트를 처리하도록 변경되었습니다.
  * 도서 조회/생성 흐름이 엔터티 반환 방식으로 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->